### PR TITLE
chore: prepare Vercel deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,19 @@ npm run lint
 npx prisma db push
 ```
 
+## Deployment auf Vercel
+
+1. Erstelle ein Konto auf [vercel.com](https://vercel.com/) und importiere
+   dieses Repository.
+2. Beim Import erkennt Vercel die bereitgestellte `vercel.json`. Das Frontend
+   wird mit `npm run build` in `frontend` gebaut und als statische Dateien
+   ausgeliefert.
+3. Die Express-API wird als Serverless Function unter `/api` bereitgestellt.
+4. Lege in den Projekteinstellungen die notwendigen Umgebungsvariablen an,
+   z.B. `DATABASE_URL` und `JWT_SECRET`.
+5. Starte den ersten Deploy. Anschließend ist das Frontend über die vergebene
+   Vercel‑URL erreichbar und API‑Aufrufe laufen über `/api`.
+
 ## GitHub Actions
 
 A basic workflow installs dependencies, runs lints and builds the project. Feel

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -15,6 +15,8 @@
         "pg": "^8.11.1"
       },
       "devDependencies": {
+        "@types/express": "^4.17.17",
+        "@types/jsonwebtoken": "^9.0.2",
         "@typescript-eslint/eslint-plugin": "^6.7.0",
         "@typescript-eslint/parser": "^6.7.0",
         "eslint": "^8.49.0",
@@ -372,10 +374,89 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.6",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.6.tgz",
+      "integrity": "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/express": {
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.23.tgz",
+      "integrity": "sha512-Crp6WY9aTYP3qPi2wGDo9iUe/rceX01UMhnF1jmwDcKCFM6cx7YhGP/Mpr3y9AASpfHixIG0E6azCcL5OcDHsQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^4.17.33",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "4.19.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.19.6.tgz",
+      "integrity": "sha512-N4LZ2xG7DatVqhCZzOGb1Yi5lMbXSZcmdLDe9EzSndPV2HpWYWzRbaerl2n27irrm94EPpprqa8KpskPT085+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
+      "integrity": "sha512-r8Tayk8HJnX0FztbZN7oVqGccWgw98T/0neJphO91KkmOzug1KkofZURD4UaD5uH8AqcFLfdPErnBod0u71/qg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/jsonwebtoken": {
+      "version": "9.0.10",
+      "resolved": "https://registry.npmjs.org/@types/jsonwebtoken/-/jsonwebtoken-9.0.10.tgz",
+      "integrity": "sha512-asx5hIG9Qmf/1oStypjanR7iKTv0gXQ1Ov/jfrX6kS/EO0OFni8orbmGCn0672NHR3kXHwpAwR+B368ZGN/2rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
       "dev": true,
       "license": "MIT"
     },
@@ -385,10 +466,23 @@
       "integrity": "sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.8.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.14.0",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.14.0.tgz",
+      "integrity": "sha512-eOunJqu0K1923aExK6y8p6fsihYEn/BYuQ4g0CxAAgFc4b/ZLN4CrsRZ55srTdqoiLzU2B2evC+apEIxprEzkQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/semver": {
       "version": "7.7.0",
@@ -396,6 +490,29 @@
       "integrity": "sha512-k107IF4+Xr7UHjwDc7Cfd6PRQfbdkiRabXGRjo07b4WyPahFBZCZ1sE+BNxYIJPPg73UkfOsVOLwqVc/6ETrIA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.5",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.5.tgz",
+      "integrity": "sha512-z6F2D3cOStZvuk2SaP6YrwkNO65iTZcwA2ZkSABegdkAh/lf+Aa/YQndZVfmEXT5vgAp6zv06VQ3ejSVjAny4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.8",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.8.tgz",
+      "integrity": "sha512-roei0UY3LhpOJvjbIP6ZZFngyLKl5dskOtDhxY5THRSpO+ZI+nzJ+m5yUMzGrp89YRa7lvknKkMYjqQFGwA7Sg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
     },
     "node_modules/@types/strip-bom": {
       "version": "3.0.0",
@@ -3798,8 +3915,7 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.8.0.tgz",
       "integrity": "sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==",
       "dev": true,
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -22,6 +22,8 @@
     "prisma": "^5.5.0",
     "eslint": "^8.49.0",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
-    "@typescript-eslint/parser": "^6.7.0"
+    "@typescript-eslint/parser": "^6.7.0",
+    "@types/express": "^4.17.17",
+    "@types/jsonwebtoken": "^9.0.2"
   }
 }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,4 +1,4 @@
-import express from 'express';
+import express, { Request, Response } from 'express';
 import jwt from 'jsonwebtoken';
 import { PrismaClient } from '@prisma/client';
 
@@ -8,13 +8,13 @@ app.use(express.json());
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
-app.post('/login', (req, res) => {
+app.post('/login', (req: Request, res: Response) => {
   const { email } = req.body;
   const token = jwt.sign({ email }, JWT_SECRET, { expiresIn: '1h' });
   res.json({ token });
 });
 
-app.get('/protected', (req, res) => {
+app.get('/protected', (req: Request, res: Response) => {
   const auth = req.headers.authorization;
   if (!auth) return res.status(401).end();
   try {
@@ -25,12 +25,12 @@ app.get('/protected', (req, res) => {
   }
 });
 
-app.get('/firestations', async (_req, res) => {
+app.get('/firestations', async (_req: Request, res: Response) => {
   const stations = await prisma.fireStation.findMany();
   res.json(stations);
 });
 
-app.post('/firestations', async (req, res) => {
+app.post('/firestations', async (req: Request, res: Response) => {
   try {
     const { name, contact, address } = req.body;
     const station = await prisma.fireStation.create({
@@ -42,14 +42,14 @@ app.post('/firestations', async (req, res) => {
   }
 });
 
-app.get('/equipment', async (_req, res) => {
+app.get('/equipment', async (_req: Request, res: Response) => {
   const items = await prisma.equipment.findMany({
     include: { station: true },
   });
   res.json(items);
 });
 
-app.post('/equipment', async (req, res) => {
+app.post('/equipment', async (req: Request, res: Response) => {
   try {
     const { serial, type, model, manufacturer, stationId } = req.body;
     const item = await prisma.equipment.create({
@@ -61,12 +61,12 @@ app.post('/equipment', async (req, res) => {
   }
 });
 
-app.get('/masks', async (_req, res) => {
+app.get('/masks', async (_req: Request, res: Response) => {
   const masks = await prisma.mask.findMany({ include: { station: true } });
   res.json(masks);
 });
 
-app.post('/masks', async (req, res) => {
+app.post('/masks', async (req: Request, res: Response) => {
   try {
     const { serial, model, manufacturer, stationId } = req.body;
     const mask = await prisma.mask.create({
@@ -78,7 +78,7 @@ app.post('/masks', async (req, res) => {
   }
 });
 
-app.get('/inspections', async (_req, res) => {
+app.get('/inspections', async (_req: Request, res: Response) => {
   const inspections = await prisma.inspection.findMany({
     include: { equipment: true, mask: true },
     orderBy: { date: 'desc' },
@@ -86,7 +86,7 @@ app.get('/inspections', async (_req, res) => {
   res.json(inspections);
 });
 
-app.post('/inspections', async (req, res) => {
+app.post('/inspections', async (req: Request, res: Response) => {
   const { equipmentId, maskId, notes, date } = req.body;
   if (!equipmentId && !maskId) {
     return res.status(400).json({ error: 'equipmentId or maskId required' });
@@ -102,4 +102,9 @@ app.post('/inspections', async (req, res) => {
 });
 
 const port = parseInt(process.env.PORT || '3000', 10);
-app.listen(port, () => console.log(`API running on :${port}`));
+
+if (require.main === module) {
+  app.listen(port, () => console.log(`API running on :${port}`));
+}
+
+export default app;

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,10 @@
+{
+  "builds": [
+    { "src": "backend/src/index.ts", "use": "@vercel/node" },
+    { "src": "frontend/package.json", "use": "@vercel/static-build", "config": { "distDir": "dist" } }
+  ],
+  "routes": [
+    { "src": "/api/(.*)", "dest": "backend/src/index.ts" },
+    { "src": "/(.*)", "dest": "/frontend/dist/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- export Express server for serverless usage and add type definitions
- add Vercel configuration and deployment docs

## Testing
- `npm run lint` in `frontend`
- `npm run lint` in `backend`
- `npm run build` in `backend`


------
https://chatgpt.com/codex/tasks/task_e_689744da84c08321a96bff1240484653