### PR TITLE
Fix Vercel static file routing

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,6 +5,6 @@
   ],
   "routes": [
     { "src": "/api/(.*)", "dest": "backend/src/index.ts" },
-    { "src": "/(.*)", "dest": "/frontend/dist/$1" }
+    { "src": "/(.*)", "dest": "frontend/dist/$1" }
   ]
 }


### PR DESCRIPTION
## Summary
- fix static file routing in `vercel.json`

## Testing
- `npm run lint` (frontend)
- `npm test` (frontend) *(fails: Missing script "test")*
- `npm run lint` (backend)
- `npm test` (backend) *(fails: Missing script "test")*
- `npx -y vercel --prod` *(requires setup: Set up and deploy "/workspace/pocsag-web"?)*

------
https://chatgpt.com/codex/tasks/task_e_689749bc8be08321ba3e5064a0bde832